### PR TITLE
Make write faster on 64-bit platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ repository = "https://github.com/rust-lang-nursery/rustc-hash"
 
 [dependencies]
 byteorder = "1.1"
+
+[profile.release]
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-hash"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["The Rust Project Developers"]
 description = "speed, non-cryptographic hash used in rustc"
 license = "Apache-2.0/MIT"


### PR DESCRIPTION
This code uses the same loop structure as https://github.com/tkaitchuck/aHash cc @tkaitchuck

Benchmark which interns and hashes identifiers from `syntex_syntax`:
```
intern_fx_old [19.596 ms 20.164 ms 20.822 ms]
intern_fx_new [17.790 ms 17.843 ms 17.960 ms]
intern_ahash_fallback [20.060 ms 20.243 ms 20.375 ms]
intern_ahash_aes [15.006 ms 15.103 ms 15.203 ms]
                       
hash_fx_old [5.5632 ms 5.5853 ms 5.6074 ms]
hash_fx_new [5.2823 ms 5.3044 ms 5.3371 ms]
hash_ahash_fallback [6.1036 ms 6.1093 ms 6.1173 ms]
hash_ahash_aes [5.2445 ms 5.2705 ms 5.2833 ms]
```