### PR TITLE
Add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,10 @@ readme = "README.md"
 keywords = ["hash", "fxhash", "rustc"]
 repository = "https://github.com/rust-lang-nursery/rustc-hash"
 
+[features]
+std = []
+default = ["std"]
+
 [dependencies]
-byteorder = "1.1"
+# We don't use the `byteorder/std` feature, even when we use std ourselves.
+byteorder = { version = "1.1", default-features = false }

--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ use rustc_hash::FxHashMap;
 let map: FxHashMap<u32, u32> = FxHashMap::default();
 map.insert(22, 44);
 ```
+
+### `no_std`
+
+This crate can be used as a `no_std` crate by disabling the `std`
+feature, which is on by default, as follows:
+
+```toml
+rustc-hash = { version = "1.0", default-features = false }
+```
+
+In this configuration, `FxHasher` is the only export, and the
+`FxHashMap`/`FxHashSet` type aliases are omitted.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,21 +18,30 @@
 //! map.insert(22, 44);
 //! ```
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 extern crate byteorder;
 
+#[cfg(feature = "std")]
+extern crate core;
+
+#[cfg(feature = "std")]
 use std::collections::{HashMap, HashSet};
-use std::default::Default;
-use std::hash::{Hasher, BuildHasherDefault};
-use std::ops::BitXor;
-use std::mem::size_of;
+
+use core::default::Default;
+use core::hash::Hasher;
+use core::ops::BitXor;
+use core::mem::size_of;
 
 use byteorder::{ByteOrder, NativeEndian};
 
 /// Type alias for a hashmap using the `fx` hash algorithm.
-pub type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+#[cfg(feature = "std")]
+pub type FxHashMap<K, V> = HashMap<K, V, std::hash::BuildHasherDefault<FxHasher>>;
 
 /// Type alias for a hashmap using the `fx` hash algorithm.
-pub type FxHashSet<V> = HashSet<V, BuildHasherDefault<FxHasher>>;
+#[cfg(feature = "std")]
+pub type FxHashSet<V> = HashSet<V, std::hash::BuildHasherDefault<FxHasher>>;
 
 /// A speedy hash algorithm for use within rustc. The hashmap in liballoc
 /// by default uses SipHash which isn't quite as speedy as we want. In the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,14 @@
 //! # Example
 //!
 //! ```rust
+//! # #[cfg(feature = "std")]
+//! # fn main() {
 //! use rustc_hash::FxHashMap;
 //! let mut map: FxHashMap<u32, u32> = FxHashMap::default();
 //! map.insert(22, 44);
+//! # }
+//! # #[cfg(not(feature = "std"))]
+//! # fn main() { }
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
There are cases when you'd just like the hash function from this, and not the type-aliases for the hash map. For example, when using a custom hash-map implementation. This is opt-in, and by default `std` and the type aliases are present.

This patch has one problem which I'm not sure how to fix: when it's compiled without std, the main example doctest fails, since `rustc_hash::FxHashMap` is unavailable. Replacing the example's `use rustc_hash::FxHashMap` with a few lines defining it inside the tests works fixes the issue, but is hurting the documentation for the very common use-case where the std feature is on.

Because of that I left the documentation as-is, even though `cargo test --no-default-features` fails. Let me know what you'd like me to do.