### PR TITLE
Remove byteorder dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,3 @@ license = "Apache-2.0/MIT"
 readme = "README.md"
 keywords = ["hash", "fxhash", "rustc"]
 repository = "https://github.com/rust-lang-nursery/rustc-hash"
-
-[dependencies]
-byteorder = "1.1"


### PR DESCRIPTION
Background: Due to https://github.com/rust-lang/cargo/issues/4866, `no_std` targets are constantly fighting against dependencies having `std`-triggering default features activated. This library is a dependency of `bindgen` which quite often has this issue, particularly because of the `byteorder` library which sees quite widespread use. Even though like here it is no longer necessary.

I'm not what if any MSRV policy is in place? An alternative solution would be to keep the `byteorder` dependency, but set `default-features = false`. I could amend the PR if this solution is preferred.

It would be great to have a release with this patch then.
