### PR TITLE
Bump version to 1.1.0 (already published)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "rustc-hash"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["The Rust Project Developers"]
-description = "speed, non-cryptographic hash used in rustc"
+description = "speedy, non-cryptographic hash used in rustc"
 license = "Apache-2.0/MIT"
 readme = "README.md"
 keywords = ["hash", "fxhash", "rustc"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This crate can be used as a `no_std` crate by disabling the `std`
 feature, which is on by default, as follows:
 
 ```toml
-rustc-hash = { version = "1.0", default-features = false }
+rustc-hash = { version = "1.1", default-features = false }
 ```
 
 In this configuration, `FxHasher` is the only export, and the


### PR DESCRIPTION
This version has already been published, yet the version change never
arrived in the repo. Let's bump that in the Cargo.toml and README,
so people don't copy old versions.

Let's also fix a typo, speed -> speedy