### PR TITLE
Derive `Clone` for `FxHasher`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub type FxHashSet<V> = HashSet<V, BuildHasherDefault<FxHasher>>;
 /// out-performs an FNV-based hash within rustc itself -- the collision rate is
 /// similar or slightly worse than FNV, but the speed of the hash function
 /// itself is much higher because it works on up to 8 bytes at a time.
+#[derive(Clone)]
 pub struct FxHasher {
     hash: usize,
 }


### PR DESCRIPTION
Other common [`Hasher`](https://doc.rust-lang.org/stable/std/hash/trait.Hasher.html) implementations, including [`DefaultHasher`](https://doc.rust-lang.org/stable/std/collections/hash_map/struct.DefaultHasher.html) and [`SipHasher`](https://doc.rust-lang.org/stable/std/hash/struct.SipHasher.html), implement `Clone`—but `FxHasher` does not.

This is useful when a partially constructed hash can continue to be constructed in different ways.  For example, when the hash of a leaf in a tree structure is determined by its path from the root: it can be unnecessarily expensive to independently hash the whole path for each leaf, as one can instead traverse the tree extending the hash of the parent node as one descends.

closes #23