### PR TITLE
RFC: Optimize for small strings to close gap with FNV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ rand = ["dep:rand", "std"]
 
 [dependencies]
 rand = { version = "0.8", optional = true }
+
+[dev-dependencies]
+fnv = "1.0"
+rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.0.0"
 authors = ["The Rust Project Developers"]
 description = "speedy, non-cryptographic hash used in rustc"
 license = "Apache-2.0/MIT"

--- a/benches/strings.rs
+++ b/benches/strings.rs
@@ -1,0 +1,81 @@
+#![feature(test)]
+
+extern crate fnv;
+extern crate rand;
+extern crate rustc_hash;
+
+extern crate test;
+use test::{black_box, Bencher};
+
+use std::collections::HashSet;
+use std::hash::BuildHasher;
+
+use fnv::FnvHashSet;
+use rand::{distributions::Alphanumeric, rngs::StdRng, Rng, SeedableRng};
+use rustc_hash::FxHashSet;
+
+fn strings<const N: usize, const M: usize, H>() -> HashSet<String, H>
+where
+    H: BuildHasher + Default,
+{
+    let mut strings = HashSet::default();
+
+    let rng = &mut StdRng::seed_from_u64(42);
+
+    while strings.len() < M {
+        let length = rng.gen_range(0..N);
+
+        let string: String = rng
+            .sample_iter(&Alphanumeric)
+            .take(length)
+            .map(char::from)
+            .collect();
+
+        strings.insert(string);
+    }
+
+    strings
+}
+
+fn find_strings<H>(strings: &HashSet<String, H>) -> bool
+where
+    H: BuildHasher,
+{
+    let haystack = black_box(strings);
+    let needles = black_box(strings);
+
+    needles.iter().all(|needle| haystack.contains(needle))
+}
+
+macro_rules! compare_fx_fnv {
+    ($name:ident, $string_length:expr, $table_size:expr) => {
+        mod $name {
+            use super::*;
+
+            #[bench]
+            fn fx(bencher: &mut Bencher) {
+                let strings: FxHashSet<String> = strings::<$string_length, $table_size, _>();
+                bencher.iter(|| find_strings(&strings));
+            }
+
+            #[bench]
+            fn fnv(bencher: &mut Bencher) {
+                let strings: FnvHashSet<String> = strings::<$string_length, $table_size, _>();
+                bencher.iter(|| find_strings(&strings));
+            }
+        }
+    };
+}
+
+compare_fx_fnv!(few_tiny, 3, 1_000);
+compare_fx_fnv!(few_small, 7, 1_000);
+compare_fx_fnv!(few_medium, 15, 1_000);
+compare_fx_fnv!(few_large, 47, 1_000);
+
+compare_fx_fnv!(some_small, 7, 10_000);
+compare_fx_fnv!(some_medium, 15, 10_000);
+compare_fx_fnv!(some_large, 47, 10_000);
+
+compare_fx_fnv!(many_small, 7, 100_000);
+compare_fx_fnv!(many_medium, 15, 100_000);
+compare_fx_fnv!(many_large, 47, 100_000);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,13 +123,12 @@ impl Hasher for FxHasher {
             hash.add_to_hash(u32::from_ne_bytes(chunk.try_into().unwrap()) as usize);
             bytes = rest;
         }
-        if SIZE > 2 && bytes.len() >= 2 {
-            let (chunk, rest) = bytes.split_at(2);
-            hash.add_to_hash(u16::from_ne_bytes(chunk.try_into().unwrap()) as usize);
-            bytes = rest;
-        }
-        if SIZE > 1 && bytes.len() >= 1 {
-            hash.add_to_hash(bytes[0] as usize);
+        if !bytes.is_empty() {
+            let mut chunk = 0;
+            for &byte in bytes {
+                chunk = chunk << 8 | byte as usize;
+            }
+            hash.add_to_hash(chunk);
         }
 
         *self = hash;
@@ -288,7 +287,7 @@ mod tests {
             hash(HashBytes(&[0, 0, 0, 0, 0, 0])) == 0,
             hash(HashBytes(&[1])) == if B32 { 2654435769 } else { 5871781006564002453 },
             hash(HashBytes(&[2])) == if B32 { 1013904242 } else { 11743562013128004906 },
-            hash(HashBytes(b"uwu")) == if B32 { 3939043750 } else { 16622306935539548858 },
+            hash(HashBytes(b"uwu")) == if B32 { 3128729741 } else { 14178895633054898457 },
             hash(HashBytes(b"These are some bytes for testing rustc_hash.")) == if B32 { 2345708736 } else { 12390864548135261390 },
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,29 +104,35 @@ impl FxHasher {
 impl Hasher for FxHasher {
     #[inline]
     fn write(&mut self, mut bytes: &[u8]) {
-        #[cfg(target_pointer_width = "32")]
-        let read_usize = |bytes: &[u8]| u32::from_ne_bytes(bytes[..4].try_into().unwrap());
-        #[cfg(target_pointer_width = "64")]
-        let read_usize = |bytes: &[u8]| u64::from_ne_bytes(bytes[..8].try_into().unwrap());
+        const SIZE: usize = {
+            let size = size_of::<usize>();
+            assert!(1 <= size && size <= 8);
+            size
+        };
 
-        let mut hash = FxHasher { hash: self.hash };
-        assert!(size_of::<usize>() <= 8);
-        while bytes.len() >= size_of::<usize>() {
-            hash.add_to_hash(read_usize(bytes) as usize);
-            bytes = &bytes[size_of::<usize>()..];
+        let mut hash = self.clone();
+
+        while bytes.len() >= SIZE {
+            let (chunk, rest) = bytes.split_at(SIZE);
+            hash.add_to_hash(usize::from_ne_bytes(chunk.try_into().unwrap()));
+            bytes = rest;
         }
-        if (size_of::<usize>() > 4) && (bytes.len() >= 4) {
-            hash.add_to_hash(u32::from_ne_bytes(bytes[..4].try_into().unwrap()) as usize);
-            bytes = &bytes[4..];
+
+        if SIZE > 4 && bytes.len() >= 4 {
+            let (chunk, rest) = bytes.split_at(4);
+            hash.add_to_hash(u32::from_ne_bytes(chunk.try_into().unwrap()) as usize);
+            bytes = rest;
         }
-        if (size_of::<usize>() > 2) && bytes.len() >= 2 {
-            hash.add_to_hash(u16::from_ne_bytes(bytes[..2].try_into().unwrap()) as usize);
-            bytes = &bytes[2..];
+        if SIZE > 2 && bytes.len() >= 2 {
+            let (chunk, rest) = bytes.split_at(2);
+            hash.add_to_hash(u16::from_ne_bytes(chunk.try_into().unwrap()) as usize);
+            bytes = rest;
         }
-        if (size_of::<usize>() > 1) && bytes.len() >= 1 {
+        if SIZE > 1 && bytes.len() >= 1 {
             hash.add_to_hash(bytes[0] as usize);
         }
-        self.hash = hash.hash;
+
+        *self = hash;
     }
 
     #[inline]


### PR DESCRIPTION
Over [at Tantivy](https://github.com/quickwit-oss/tantivy/pull/2280), I proposed standardizing on `rustc-hash` by replacing the remaining usages of FNV. However, it appears FNV still beats `rustc-hash` for very short strings.
 
Hence I added a microbenchmark here exploring this which showcase this:

```console
test few_large::fnv   ... bench:      19,621 ns/iter (+/- 120)
test few_large::fx    ... bench:       9,355 ns/iter (+/- 166)
test few_medium::fnv  ... bench:       9,356 ns/iter (+/- 98)
test few_medium::fx   ... bench:       7,898 ns/iter (+/- 115)
test few_small::fnv   ... bench:       7,300 ns/iter (+/- 60)
test few_small::fx    ... bench:       7,337 ns/iter (+/- 109)
test few_tiny::fnv    ... bench:       6,936 ns/iter (+/- 50) <- significant win for FNV
test few_tiny::fx     ... bench:       7,513 ns/iter (+/- 84)
test many_large::fnv  ... bench:   3,883,669 ns/iter (+/- 26,968)
test many_large::fx   ... bench:   2,233,341 ns/iter (+/- 14,412)
test many_medium::fnv ... bench:   2,071,061 ns/iter (+/- 14,305)
test many_medium::fx  ... bench:   1,677,142 ns/iter (+/- 10,292)
test many_small::fnv  ... bench:   1,471,003 ns/iter (+/- 25,075)
test many_small::fx   ... bench:   1,336,677 ns/iter (+/- 8,678)
test some_large::fnv  ... bench:     309,672 ns/iter (+/- 22,118)
test some_large::fx   ... bench:     196,661 ns/iter (+/- 4,512)
test some_medium::fnv ... bench:     158,861 ns/iter (+/- 2,246)
test some_medium::fx  ... bench:     151,262 ns/iter (+/- 3,039)
test some_small::fnv  ... bench:     119,939 ns/iter (+/- 3,410) <- small win for FNV
test some_small::fx   ... bench:     120,153 ns/iter (+/- 749)
```

I also made two changes. First using only safe code but changing the output values which does close the gap. And then using a bit of unsafe (but still passing Miri) to polyfill for `slice::as_chunks`. After that, we do beat FNV in the two above cases but regress in one other even we generally improve:

```console
test few_large::fnv   ... bench:      19,846 ns/iter (+/- 174)
test few_large::fx    ... bench:       8,206 ns/iter (+/- 70)
test few_medium::fnv  ... bench:       9,318 ns/iter (+/- 94)
test few_medium::fx   ... bench:       6,917 ns/iter (+/- 71)
test few_small::fnv   ... bench:       7,288 ns/iter (+/- 69)
test few_small::fx    ... bench:       6,679 ns/iter (+/- 69)
test few_tiny::fnv    ... bench:       6,884 ns/iter (+/- 82)
test few_tiny::fx     ... bench:       6,421 ns/iter (+/- 72)
test many_large::fnv  ... bench:   3,838,407 ns/iter (+/- 67,395)
test many_large::fx   ... bench:   1,912,792 ns/iter (+/- 21,136)
test many_medium::fnv ... bench:   2,079,771 ns/iter (+/- 16,490)
test many_medium::fx  ... bench:   1,580,259 ns/iter (+/- 19,684)
test many_small::fnv  ... bench:   1,482,612 ns/iter (+/- 13,102)
test many_small::fx   ... bench:   1,634,143 ns/iter (+/- 15,159) <- we regress and loose to FNV
test some_large::fnv  ... bench:     317,275 ns/iter (+/- 20,146)
test some_large::fx   ... bench:     169,852 ns/iter (+/- 1,669)
test some_medium::fnv ... bench:     158,647 ns/iter (+/- 4,668)
test some_medium::fx  ... bench:     135,808 ns/iter (+/- 556)
test some_small::fnv  ... bench:     120,479 ns/iter (+/- 1,543)
test some_small::fx   ... bench:     115,738 ns/iter (+/- 1,121)
```

So, first I wanted to ask if upstream is interested in optimizing for small strings to make rustc-hash more generally useful at all. And then if breaking value stability is possible at all or whether such a change cannot be done even as a breaking change.