### PR TITLE
`const fn`-ify what can be `const` of the API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ const K: usize = 0x517cc1b727220a95;
 fn take_first_chunk<'a, const N: usize>(slice: &mut &'a [u8]) -> Option<&'a [u8; N]> {
     // TODO: use [T]::split_first_chunk() when stable
     if slice.len() < N {
-        return None
+        return None;
     }
 
     let (first, rest) = slice.split_at(N);
@@ -94,15 +94,20 @@ fn take_first_chunk<'a, const N: usize>(slice: &mut &'a [u8]) -> Option<&'a [u8;
 
 impl FxHasher {
     /// Creates `fx` hasher with a given seed.
-    pub fn with_seed(seed: usize) -> FxHasher {
+    pub const fn with_seed(seed: usize) -> FxHasher {
         FxHasher { hash: seed }
+    }
+
+    /// Create a default `fq` hasher.
+    pub const fn default() -> FxHasher {
+        FxHasher { hash: 0 }
     }
 }
 
 impl Default for FxHasher {
     #[inline]
     fn default() -> FxHasher {
-        FxHasher { hash: 0 }
+        Self::default()
     }
 }
 

--- a/src/seeded_state.rs
+++ b/src/seeded_state.rs
@@ -24,7 +24,7 @@ pub struct FxSeededState {
 
 impl FxSeededState {
     /// Constructs a new `FxSeededState` that is initialized with a `seed`.
-    pub fn with_seed(seed: usize) -> FxSeededState {
+    pub const fn with_seed(seed: usize) -> FxSeededState {
         Self { seed }
     }
 }


### PR DESCRIPTION
This helps to remove lazy initialization to initialize global static variables containing `FxHashMap`/`FxHashSet`.