### PR TITLE
Bump version to 2.0.0 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+## 1.3.0
+
+- Replace hash with faster and better finalized hash.
+  This replaces the previous "fxhash" algorithm originating in Firefox
+  with a custom hasher designed and implemented by Orson Peters ([`@orlp`](https://github.com/orlp)).
+  It was measured to have slightly better performance for rustc, has better theoretical properties
+  and also includes a signficantly better string hasher.
+- Fix `no_std` builds
+
+## 1.2.0 (**YANKED**)
+
+**Note: This version has been yanked due to issues with the `no_std` feature!**
+
+- Add a `FxBuildHasher` unit struct
+- Improve documentation
+- Add seed API for supplying custom seeds other than 0
+- Add `FxRandomState` based on `rand` (behind the `rand` feature) for random seeds
+- Make many functions `const fn`
+- Implement `Clone` for `FxHasher` struct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.0
+## 2.0.0
 
 - Replace hash with faster and better finalized hash.
   This replaces the previous "fxhash" algorithm originating in Firefox

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-hash"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["The Rust Project Developers"]
 description = "A speedy, non-cryptographic hashing algorithm used by rustc"
 license = "Apache-2.0/MIT"

--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ The `std` feature is on by default to enable collections.
 It can be turned off in `Cargo.toml` like so:
 
 ```toml
-rustc-hash = { version = "1.3", default-features = false }
+rustc-hash = { version = "2.0", default-features = false }
 ```

--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ The `std` feature is on by default to enable collections.
 It can be turned off in `Cargo.toml` like so:
 
 ```toml
-rustc-hash = { version = "1.2", default-features = false }
+rustc-hash = { version = "1.3", default-features = false }
 ```


### PR DESCRIPTION
This adds a changelog for all the changes in 1.2.0 and 1.3.0 and then bumps the version to 1.3.0 for the next release.

I chose a minor version, but there is an argument to be made for this being a major version, as the crate *does* document that it's fxhash. But given that the fxhash output is not really stable and differs between platforms anyways, I think it makes sense to say that the precise numbers were never guaranteed to be stable, and that this is therefore a minor release.