### PR TITLE
Improve CI with proper test jobs + fmt/doc/clippy

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,10 +23,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - run: rustup default stable
+      - run: rustup update stable && rustup default stable
       - run: cargo check
       - run: cargo test
-      - run: rustup default nightly
+      - run: rustup update nightly && rustup default nightly
       - run: cargo test --all-features
   cross-test:
     strategy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,19 +1,73 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTUP_MAX_RETRIES: 10
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: rust-lang/simpleinfra/github-actions/simple-ci@master
-    - name: "32-bit cross testing"
-      run: |
-        rustup toolchain install nightly
-        rustup override set nightly
-        rustup component add miri
-        cargo +nightly miri test --target i686-unknown-linux-gnu
+  test:
     strategy:
       matrix:
         os: [ubuntu, windows, macos]
+    runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup default stable
+      - run: cargo check
+      - run: cargo test
+      - run: rustup default nightly
+      - run: cargo test --all-features
+  cross-test:
+    strategy:
+      matrix:
+        target: [
+            "x86_64-unknown-linux-gnu", # 64-bits, little-endian
+            "i686-unknown-linux-gnu", # 32-bits, little-endian
+            "mips-unknown-linux-gnu", # 32-bits, big-endian
+            "mips64-unknown-linux-gnuabi64", # 64-bits, big-endian
+          ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: install miri
+        run: rustup toolchain add nightly --no-self-update --component miri && rustup default nightly
+      - run: |
+          cargo miri test --target=${{ matrix.target }} --all-features
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance
+          RUSTDOCFLAGS: ${{ env.RUSTDOCFLAGS }} -Z randomize-layout
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} -Z randomize-layout
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: rustup component add rustfmt
+      - run: cargo fmt --all --check
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: cargo doc --workspace --document-private-items --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update stable && rustup default stable
+      - run: rustup component add clippy
+      - run: cargo clippy --workspace --all-targets --no-deps

--- a/src/seeded_state.rs
+++ b/src/seeded_state.rs
@@ -8,7 +8,7 @@ pub type FxHashMapSeed<K, V> = std::collections::HashMap<K, V, FxSeededState>;
 #[cfg(feature = "std")]
 pub type FxHashSetSeed<V> = std::collections::HashSet<V, FxSeededState>;
 
-/// [`FxSetState`] is an alternative state for `HashMap` types, allowing to use [`FxHasher`] with a set seed.
+/// [`FxSeededState`] is an alternative state for `HashMap` types, allowing to use [`FxHasher`] with a set seed.
 ///
 /// ```
 /// # use std::collections::HashMap;


### PR DESCRIPTION
Mainly imported from rustc-stable-hash CI[^1].

Related to https://github.com/rust-lang/simpleinfra/issues/445 (cc @MarcoIeni).

[^1]:
https://github.com/rust-lang/rustc-stable-hash/blob/cc85b7a5940308df8329d3812bc27dc0a2fd3a50/.github/workflows/rust.yml