### PR TITLE
chore: add testcase to `seeded_state`

### DIFF
--- a/src/seeded_state.rs
+++ b/src/seeded_state.rs
@@ -44,6 +44,16 @@ mod tests {
     use crate::FxSeededState;
 
     #[test]
+    fn same_seed_produces_same_hasher() {
+        let seed = 1;
+        let a = FxSeededState::with_seed(seed);
+        let b = FxSeededState::with_seed(seed);
+
+        // The hashers should be the same, as they have the same seed.
+        assert_eq!(a.build_hasher().hash, b.build_hasher().hash);
+    }
+
+    #[test]
     fn different_states_are_different() {
         let a = FxSeededState::with_seed(1);
         let b = FxSeededState::with_seed(2);


### PR DESCRIPTION
### Purpose
Verify that FxSeededState instances with the same seed produce the same hasher.

### Description
This test confirms that using the same seed value results in identical hashers. 
This ensures that the internal state of FxHasher is consistent for instances created with the same seed value.