### PR TITLE
Derive Clone for FxRandomState and FxSeededState

### DIFF
--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -65,7 +65,6 @@ mod tests {
 
     #[test]
     fn cloned_random_states_are_equal() {
-        // The standard library's `RandomState` derives `Clone` without updating the seed.
         let a = FxHashMapRand::<&str, u32>::default();
         let b = a.clone();
 

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -13,6 +13,7 @@ pub type FxHashSetRand<V> = HashSet<V, FxRandomState>;
 /// A particular instance `FxRandomState` will create the same instances of
 /// [`Hasher`], but the hashers created by two different `FxRandomState`
 /// instances are unlikely to produce the same result for the same values.
+#[derive(Clone)]
 pub struct FxRandomState {
     seed: usize,
 }
@@ -61,6 +62,15 @@ mod tests {
     use std::thread;
 
     use crate::FxHashMapRand;
+
+    #[test]
+    fn cloned_random_states_are_equal() {
+        // The standard library's `RandomState` derives `Clone` without updating the seed.
+        let a = FxHashMapRand::<&str, u32>::default();
+        let b = a.clone();
+
+        assert_eq!(a.hasher().seed, b.hasher().seed);
+    }
 
     #[test]
     fn random_states_are_different() {

--- a/src/seeded_state.rs
+++ b/src/seeded_state.rs
@@ -18,6 +18,7 @@ pub type FxHashSetSeed<V> = std::collections::HashSet<V, FxSeededState>;
 /// map.insert(15, 610);
 /// assert_eq!(map[&15], 610);
 /// ```
+#[derive(Clone)]
 pub struct FxSeededState {
     seed: usize,
 }
@@ -42,6 +43,18 @@ mod tests {
     use core::hash::BuildHasher;
 
     use crate::FxSeededState;
+
+    #[test]
+    fn cloned_seeded_states_are_equal() {
+        let seed = 2;
+        let a = FxSeededState::with_seed(seed);
+        let b = a.clone();
+
+        assert_eq!(a.seed, b.seed);
+        assert_eq!(a.seed, seed);
+
+        assert_eq!(a.build_hasher().hash, b.build_hasher().hash);
+    }
 
     #[test]
     fn same_seed_produces_same_hasher() {


### PR DESCRIPTION
`FxRandomState` is based off of he standard library's `RandomState`, but `FxRandomState` doesn't derive `Clone`, which is required for `FxHashMapRand: Clone`.

The same is done for `FxSeededState`.