### PR TITLE
Use a folded multiply as finalizer.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["The Rust Project Developers"]
 description = "A speedy, non-cryptographic hashing algorithm used by rustc"
 license = "Apache-2.0 OR MIT"


### PR DESCRIPTION
The current finalizer consisting of a right-rotation of 20 bits can create fairly catastrophic results if the bottom input bits are low-entropy and the hash table grows beyond 2^20 elements, see https://github.com/rust-lang/rust/issues/135477#issuecomment-2614419872.

In this PR I want to try replacing the finalizer with a folded multiply instead to evenly spread the entropy across all bits. I've changed the order of the multiply and add in `add_to_hash` to ensure that for single-integer inputs we still only do one (widening) multiply. The first multiplication and addition are multiplying by/adding to zero so should be optimized out.