### PR TITLE
Update to rand 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ nightly = []
 rand = ["dep:rand", "std"]
 
 [dependencies]
-rand = { version = "0.8", optional = true }
+rand = { version = "0.9", optional = true }

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -32,7 +32,7 @@ impl FxRandomState {
         // 2. Change the cached result on every creation, so maps created
         //    on the same thread don't have the same iteration order
         thread_local!(static SEED: Cell<usize> = {
-            Cell::new(rand::thread_rng().gen())
+            Cell::new(rand::rng().random_range(..=usize::MAX))
         });
 
         SEED.with(|seed| {


### PR DESCRIPTION
Non-breaking change. Only used internally for `FxRandomState`.

`.random::<usize>()` cannot be used because `Distribution<usize> for StandardUniform` was removed.