### PR TITLE
chore(deps): bump rust crate rand minimum version to v0.8.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ nightly = []
 rand = ["dep:rand", "std"]
 
 [dependencies]
-rand = { version = "0.8", optional = true }
+rand = { version = "0.8.6", optional = true }


### PR DESCRIPTION
Closes https://github.com/rust-lang/rustc-hash/issues/69