### PR TITLE
Use derive_const in nightly feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub use seeded_state::{FxHashMapSeed, FxHashSetSeed};
 /// The current implementation is a fast polynomial hash with a single
 /// bit rotation as a finishing step designed by Orson Peters.
 #[derive(Clone)]
+#[cfg_attr(not(feature = "nightly"), derive(Default))]
+#[cfg_attr(feature = "nightly", derive_const(Default))]
 pub struct FxHasher {
     hash: usize,
 }
@@ -89,34 +91,6 @@ impl FxHasher {
         FxHasher { hash: 0 }
     }
 }
-
-#[cfg(not(feature = "nightly"))]
-macro_rules! default_impl {
-    () => {
-        impl Default for FxHasher {
-            #[inline]
-            fn default() -> FxHasher {
-                Self::default()
-            }
-        }
-    };
-}
-
-// In order to use the nightly-only `const` syntax, we gate the definition behind a macro so that
-// parsing still succeeds on stable.
-#[cfg(feature = "nightly")]
-macro_rules! default_impl {
-    () => {
-        impl const Default for FxHasher {
-            #[inline]
-            fn default() -> FxHasher {
-                Self::default()
-            }
-        }
-    };
-}
-
-default_impl!();
 
 impl FxHasher {
     #[inline]

--- a/src/random_state.rs
+++ b/src/random_state.rs
@@ -92,7 +92,7 @@ mod tests {
         // `1 / 2.pow(bit_size_of::<usize>())`. Or 1/1.7e19 for 64 bit platforms or 1/4294967295
         // for 32 bit platforms. I suppose this is acceptable.
         let a = FxHashMapRand::<&str, u32>::default();
-        let b = thread::spawn(|| FxHashMapRand::<&str, u32>::default())
+        let b = thread::spawn(FxHashMapRand::<&str, u32>::default)
             .join()
             .unwrap();
 


### PR DESCRIPTION
Feature nightly is currently broken:
```rust
error: expected a trait, found type
   --> /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustc-hash-2.1.2/src/lib.rs:110:14
    |
110 |         impl const Default for FxHasher {
    |              ^^^^^^^^^^^^^
...
119 | default_impl!();
    | --------------- in this macro invocation
    |
    = note: this error originates in the macro `default_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Fix this by using `derive_const`, and also a drive-by clippy fix.